### PR TITLE
Fix implicit declaration of gmtime_r compiler error

### DIFF
--- a/pymemtrace/src/c/pymemtrace_util.c
+++ b/pymemtrace/src/c/pymemtrace_util.c
@@ -1,6 +1,9 @@
 //
 // Created by Paul Ross on 03/11/2020.
 //
+
+#define _POSIX_C_SOURCE 200112L  // For gmtime_r in <time.h>
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <time.h>


### PR DESCRIPTION
To fix the following compile error on Linux (Ubuntu 22.04):

```
     pymemtrace/src/c/pymemtrace_util.c: In function ‘create_filename’:
      pymemtrace/src/c/pymemtrace_util.c:18:5: error: implicit declaration of function ‘gmtime_r’; did you mean ‘gmtime’? [-Werror=implicit-function-declaration]
         18 |     gmtime_r(&t, &now);
            |     ^~~~~~~~
            |     gmtime
      compilation terminated due to -Wfatal-errors.
      cc1: all warnings being treated as errors
      error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
```